### PR TITLE
Changes to DebugTargetUtils and ThreadUtils

### DIFF
--- a/simulationmodelanimation/plugins/fr.obeo.dsl.debug/src/fr/obeo/dsl/debug/DebugTargetUtils.java
+++ b/simulationmodelanimation/plugins/fr.obeo.dsl.debug/src/fr/obeo/dsl/debug/DebugTargetUtils.java
@@ -339,6 +339,7 @@ public final class DebugTargetUtils {
 				res = currentFrame;
 				break;
 			}
+			currentFrame = currentFrame.getChildFrame();
 		}
 
 		return res;

--- a/simulationmodelanimation/plugins/fr.obeo.dsl.debug/src/fr/obeo/dsl/debug/ThreadUtils.java
+++ b/simulationmodelanimation/plugins/fr.obeo.dsl.debug/src/fr/obeo/dsl/debug/ThreadUtils.java
@@ -142,14 +142,14 @@ public final class ThreadUtils {
 	 *            the {@link Thread}
 	 */
 	public static void suspendedReply(Thread thread) {
-		final StackFrame topStackFrame = thread.getTopStackFrame();
+		// final StackFrame topStackFrame = thread.getTopStackFrame();
 		final State state = thread.getState();
 		if (thread.getDebugTarget().getState() == DebugTargetState.CONNECTED
 				&& (state == State.SUSPENDING || isActiveStat(state))) {
 			thread.setState(State.SUSPENDED);
-			if (topStackFrame != null) {
-				ThreadUtils.unchangeVariables(thread);
-			}
+			// if (topStackFrame != null) {
+			ThreadUtils.unchangeVariables(thread);
+			// }
 		} else {
 			throw new IllegalStateException(
 					"a suspend reply must happend when the thread is suspending, running, or stepping and the debug target is connected.");
@@ -165,10 +165,15 @@ public final class ThreadUtils {
 	 */
 	private static void unchangeVariables(Thread thread) {
 		// TODO optimize by keeping track of changed variables with an adapter
-		for (Variable variable : thread.getTopStackFrame().getVariables()) {
-			if (variable.isValueChanged()) {
+		// for (Variable variable : thread.getTopStackFrame().getVariables()) {
+		StackFrame currentStackFrame = thread.getBottomStackFrame();
+		while (currentStackFrame != null) {
+			for (Variable variable : currentStackFrame.getVariables()) {
+				// if (variable.isValueChanged()) {
 				variable.setValueChanged(false);
+				// }
 			}
+			currentStackFrame = currentStackFrame.getChildFrame();
 		}
 	}
 

--- a/simulationmodelanimation/plugins/fr.obeo.dsl.debug/src/fr/obeo/dsl/debug/ThreadUtils.java
+++ b/simulationmodelanimation/plugins/fr.obeo.dsl.debug/src/fr/obeo/dsl/debug/ThreadUtils.java
@@ -147,9 +147,7 @@ public final class ThreadUtils {
 		if (thread.getDebugTarget().getState() == DebugTargetState.CONNECTED
 				&& (state == State.SUSPENDING || isActiveStat(state))) {
 			thread.setState(State.SUSPENDED);
-			// if (topStackFrame != null) {
 			ThreadUtils.unchangeVariables(thread);
-			// }
 		} else {
 			throw new IllegalStateException(
 					"a suspend reply must happend when the thread is suspending, running, or stepping and the debug target is connected.");
@@ -169,9 +167,7 @@ public final class ThreadUtils {
 		StackFrame currentStackFrame = thread.getBottomStackFrame();
 		while (currentStackFrame != null) {
 			for (Variable variable : currentStackFrame.getVariables()) {
-				// if (variable.isValueChanged()) {
 				variable.setValueChanged(false);
-				// }
 			}
 			currentStackFrame = currentStackFrame.getChildFrame();
 		}


### PR DESCRIPTION
Fixed a bug in the getStackFrame method in DebugTargetUtils that was causing an infinite loop when the stackframe name given as paramater was not the name of the bottom stackframe.

Changed the unchangeVariables method in ThreadUtils to unchange variables in every scope instead of just the one of the top stackframe.
