### PR TITLE
[Debug-Layer generation] Fix compilation errors of generated service class

### DIFF
--- a/framework/xdsml_framework/plugins/org.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/gemoc/xdsmlframework/extensions/sirius/command/AddDebugLayerHandler.java
+++ b/framework/xdsml_framework/plugins/org.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/gemoc/xdsmlframework/extensions/sirius/command/AddDebugLayerHandler.java
@@ -66,6 +66,10 @@ import org.eclipse.sirius.viewpoint.description.tool.PopupMenu;
 import org.eclipse.sirius.viewpoint.description.tool.ToolPackage;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.handlers.HandlerUtil;
+import org.gemoc.xdsmlframework.extensions.sirius.Activator;
+import org.osgi.framework.BundleException;
+
+import fr.inria.diverse.commons.eclipse.pde.manifest.ManifestChanger;
 
 public class AddDebugLayerHandler extends AbstractHandler {
 
@@ -114,6 +118,8 @@ public class AddDebugLayerHandler extends AbstractHandler {
 										qualifiedServiceClassName);
 							}
 						});
+				
+				updateManifest(project);
 			}
 		} catch (IOException e) {
 			throw new ExecutionException(
@@ -123,6 +129,18 @@ public class AddDebugLayerHandler extends AbstractHandler {
 					"Error while creating the debug layer", e);
 		}
 		return null;
+	}
+	
+	public static void updateManifest(final IProject project){
+	  ManifestChanger changer = new ManifestChanger(project);
+    try {
+      changer.addPluginDependency("org.gemoc.executionframework.extensions.sirius");
+      changer.addPluginDependency("org.gemoc.execution.sequential.javaengine.ui");
+      changer.commit();
+    } catch (BundleException | IOException | CoreException e) {
+      Activator.getMessagingSystem().error(e.getMessage(),
+          Activator.PLUGIN_ID, e);
+    }
 	}
 
 	public static void emfModifications(final IProgressMonitor monitor,

--- a/framework/xdsml_framework/plugins/org.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/gemoc/xdsmlframework/extensions/sirius/command/debug_services_template.txt
+++ b/framework/xdsml_framework/plugins/org.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/gemoc/xdsmlframework/extensions/sirius/command/debug_services_template.txt
@@ -1,4 +1,4 @@
-package PACKAGE;
+﻿package PACKAGE;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,5 +15,10 @@ public class CLASS_NAME extends AbstractGemocDebuggerServices {
 
 		return res;
 	}
+	
+	@Override
+	public String getModelIdentifier(){
+		return org.gemoc.execution.sequential.javaengine.ui.Activator.DEBUG_MODEL_ID;
+	}	
 
 }

--- a/framework/xdsml_framework/plugins/org.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/gemoc/xdsmlframework/extensions/sirius/wizards/NewGemocDebugRepresentationWizard.java
+++ b/framework/xdsml_framework/plugins/org.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/gemoc/xdsmlframework/extensions/sirius/wizards/NewGemocDebugRepresentationWizard.java
@@ -50,9 +50,6 @@ import org.gemoc.xdsmlframework.extensions.sirius.wizards.pages.AddDebugRepresen
 import org.gemoc.xdsmlframework.extensions.sirius.wizards.pages.DebugRepresentationSelectionPage;
 import org.gemoc.xdsmlframework.extensions.sirius.wizards.pages.NewViewPointProjectPage;
 import org.gemoc.xdsmlframework.extensions.sirius.wizards.pages.SelectDiagramDefinitionPage;
-import org.osgi.framework.BundleException;
-
-import fr.inria.diverse.commons.eclipse.pde.manifest.ManifestChanger;
 
 /**
  * Wizard to create a new debug representation.
@@ -64,7 +61,7 @@ public class NewGemocDebugRepresentationWizard extends Wizard implements
 		IWorkbenchWizard {
 
 	private String initialLanguageName = "myLanguage";
-	private String initialProjectName = initialLanguageName;
+	private String initialProjectName = initialLanguageName.toLowerCase();
 
 	private class FinishRunnable implements IRunnableWithProgress {
 
@@ -100,15 +97,7 @@ public class NewGemocDebugRepresentationWizard extends Wizard implements
 					AddDebugLayerHandler.emfModifications(monitor, layerName,
 							diagramDescription, languageName,
 							qualifiedServiceClassName);
-					// Additional project configurations
-					ManifestChanger changer = new ManifestChanger(project);
-					try {
-						changer.addPluginDependency("org.gemoc.executionframework.extensions.sirius");
-						changer.commit();
-					} catch (BundleException | IOException | CoreException e) {
-						Activator.getMessagingSystem().error(e.getMessage(),
-								Activator.PLUGIN_ID, e);
-					}
+					AddDebugLayerHandler.updateManifest(project);
 				} catch (CoreException e) {
 					Activator.getMessagingSystem().error(e.getMessage(),
 							Activator.PLUGIN_ID, e);
@@ -149,15 +138,7 @@ public class NewGemocDebugRepresentationWizard extends Wizard implements
 					AddDebugLayerHandler.emfModifications(monitor, layerName,
 							diagramExtensionDescription, languageName,
 							qualifiedServiceClassName);
-					// Additional project configurations
-					ManifestChanger changer = new ManifestChanger(project);
-					try {
-						changer.addPluginDependency("org.gemoc.executionframework.extensions.sirius");
-						changer.commit();
-					} catch (BundleException | IOException | CoreException e) {
-						Activator.getMessagingSystem().error(e.getMessage(),
-								Activator.PLUGIN_ID, e);
-					}
+					AddDebugLayerHandler.updateManifest(project);
 				} catch (CoreException e) {
 					Activator.getMessagingSystem().error(e.getMessage(),
 							Activator.PLUGIN_ID, e);
@@ -215,6 +196,7 @@ public class NewGemocDebugRepresentationWizard extends Wizard implements
 					AddDebugLayerHandler.emfModifications(monitor, layerName,
 							diagramDescription, languageName,
 							qualifiedServiceClassName);
+					AddDebugLayerHandler.updateManifest(project);
 				} catch (IOException e) {
 					Activator.getMessagingSystem().error(e.getMessage(),
 							Activator.PLUGIN_ID, e);


### PR DESCRIPTION
Using UI support (wizard or context command) for adding a debug-layer to an odesign-file results in compliation errors in the corresponding *DebugServices class.

The template used for the class generation is deprecated and doesn't implement all abstract methods of AbstractGemocDebuggerServices.

This fix updates the template and adds the necessary manifest changes.

(the xMOF-GEMOC integration is reusing this functionality and with this fix a couple of isses will get resolved)