### PR TITLE
Add "IntegerObject" case to generic trace + constructor

### DIFF
--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/model/GenericTrace.ecore
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/model/GenericTrace.ecore
@@ -1,159 +1,153 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="trace" nsURI="http://www.gemoc.org/generic_trace" nsPrefix="trace">
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="trace" nsURI="http://www.gemoc.org/generic_trace" nsPrefix="trace">
   <eClassifiers xsi:type="ecore:EDataType" name="ISerializable" instanceClassName="byte[]"/>
   <eClassifiers xsi:type="ecore:EClass" name="MSEOccurrence">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="mse" lowerBound="1" eType="//MSE"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="parameters" upperBound="-1">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
-    </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="result" upperBound="-1">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="mse" lowerBound="1" eType="#//MSE"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="parameters" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="result" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="MSE" abstract="true">
-    <eSuperTypes href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//ENamedElement"/>
-    <eOperations name="getCaller">
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
-    </eOperations>
-    <eOperations name="getAction">
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
-    </eOperations>
+  <eClassifiers xsi:type="ecore:EClass" name="MSE" abstract="true" eSuperTypes="../../org.eclipse.emf.ecore/model/Ecore.ecore#//ENamedElement">
+    <eOperations name="getCaller" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
+    <eOperations name="getAction" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="MSEModel">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMSEs" upperBound="-1" eType="//MSE" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMSEs" upperBound="-1"
+        eType="#//MSE" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="GenericMSE" eSuperTypes="//MSE">
-    <eOperations name="getCaller">
+  <eClassifiers xsi:type="ecore:EClass" name="GenericMSE" eSuperTypes="#//MSE">
+    <eOperations name="getCaller" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return callerReference;"/>
       </eAnnotations>
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
     </eOperations>
-    <eOperations name="getAction">
+    <eOperations name="getAction" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return actionReference;"/>
       </eAnnotations>
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
     </eOperations>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="callerReference">
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
-    </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="actionReference">
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="callerReference" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="actionReference" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Step" abstract="true">
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="mseoccurrence" eType="//MSEOccurrence" containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="startingState" lowerBound="1" eOpposite="//State/startedSteps">
-      <eGenericType eTypeParameter="//Step/StateSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="mseoccurrence" eType="#//MSEOccurrence"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="startingState" lowerBound="1"
+        eOpposite="#//State/startedSteps">
+      <eGenericType eTypeParameter="#//Step/StateSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="endingState" eOpposite="//State/endedSteps">
-      <eGenericType eTypeParameter="//Step/StateSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="endingState" eOpposite="#//State/endedSteps">
+      <eGenericType eTypeParameter="#//Step/StateSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="BigStep" abstract="true">
     <eTypeParameters name="StepSubtype">
-      <eBounds eClassifier="//Step">
-        <eTypeArguments eTypeParameter="//BigStep/StateSubType"/>
+      <eBounds eClassifier="#//Step">
+        <eTypeArguments eTypeParameter="#//BigStep/StateSubType"/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="subSteps" upperBound="-1" containment="true">
-      <eGenericType eTypeParameter="//BigStep/StepSubtype"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subSteps" upperBound="-1"
+        containment="true">
+      <eGenericType eTypeParameter="#//BigStep/StepSubtype"/>
     </eStructuralFeatures>
-    <eGenericSuperTypes eClassifier="//Step">
-      <eTypeArguments eTypeParameter="//BigStep/StateSubType"/>
+    <eGenericSuperTypes eClassifier="#//Step">
+      <eTypeArguments eTypeParameter="#//BigStep/StateSubType"/>
     </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="SmallStep" abstract="true">
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eGenericSuperTypes eClassifier="//Step">
-      <eTypeArguments eTypeParameter="//SmallStep/StateSubType"/>
+    <eGenericSuperTypes eClassifier="#//Step">
+      <eTypeArguments eTypeParameter="#//SmallStep/StateSubType"/>
     </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="SequentialStep" abstract="true">
     <eTypeParameters name="StepSubtype">
-      <eBounds eClassifier="//Step">
-        <eTypeArguments eTypeParameter="//SequentialStep/StateSubType"/>
+      <eBounds eClassifier="#//Step">
+        <eTypeArguments eTypeParameter="#//SequentialStep/StateSubType"/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eGenericSuperTypes eClassifier="//BigStep">
-      <eTypeArguments eTypeParameter="//SequentialStep/StepSubtype"/>
-      <eTypeArguments eTypeParameter="//SequentialStep/StateSubType"/>
+    <eGenericSuperTypes eClassifier="#//BigStep">
+      <eTypeArguments eTypeParameter="#//SequentialStep/StepSubtype"/>
+      <eTypeArguments eTypeParameter="#//SequentialStep/StateSubType"/>
     </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ParallelStep" abstract="true">
     <eTypeParameters name="StepSubtype">
-      <eBounds eClassifier="//Step">
-        <eTypeArguments eTypeParameter="//ParallelStep/StateSubType"/>
+      <eBounds eClassifier="#//Step">
+        <eTypeArguments eTypeParameter="#//ParallelStep/StateSubType"/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
-        <eTypeArguments eTypeParameter="//ParallelStep/StepSubtype"/>
+      <eBounds eClassifier="#//State">
+        <eTypeArguments eTypeParameter="#//ParallelStep/StepSubtype"/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eGenericSuperTypes eClassifier="//BigStep">
-      <eTypeArguments eTypeParameter="//ParallelStep/StepSubtype"/>
-      <eTypeArguments eTypeParameter="//ParallelStep/StateSubType"/>
+    <eGenericSuperTypes eClassifier="#//BigStep">
+      <eTypeArguments eTypeParameter="#//ParallelStep/StepSubtype"/>
+      <eTypeArguments eTypeParameter="#//ParallelStep/StateSubType"/>
     </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Trace" abstract="true">
     <eTypeParameters name="StepSubType">
-      <eBounds eClassifier="//Step">
+      <eBounds eClassifier="#//Step">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="TracedObjectSubtype">
-      <eBounds eClassifier="//TracedObject">
+      <eBounds eClassifier="#//TracedObject">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="rootStep" lowerBound="1" containment="true">
-      <eGenericType eTypeParameter="//Trace/StepSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="rootStep" lowerBound="1"
+        containment="true">
+      <eGenericType eTypeParameter="#//Trace/StepSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="tracedObjects" upperBound="-1" containment="true">
-      <eGenericType eTypeParameter="//Trace/TracedObjectSubtype"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="tracedObjects" upperBound="-1"
+        containment="true">
+      <eGenericType eTypeParameter="#//Trace/TracedObjectSubtype"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1" containment="true">
-      <eGenericType eTypeParameter="//Trace/StateSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1"
+        containment="true">
+      <eGenericType eTypeParameter="#//Trace/StateSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="launchconfiguration" lowerBound="1" containment="true">
-      <eType xsi:type="ecore:EClass" href="LaunchConfiguration.ecore#//LaunchConfiguration"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="launchconfiguration" lowerBound="1"
+        eType="ecore:EClass LaunchConfiguration.ecore#//LaunchConfiguration" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TracedObject" abstract="true">
     <eTypeParameters name="DimensionSubType">
-      <eBounds eClassifier="//Dimension">
+      <eBounds eClassifier="#//Dimension">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
@@ -161,55 +155,61 @@
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="// Default implementation, returning empty list.&#xA;final EList&lt;DimensionSubType> result = new org.eclipse.emf.ecore.util.BasicInternalEList&lt;DimensionSubType>(Object.class);&#xA;return result;"/>
       </eAnnotations>
-      <eGenericType eTypeParameter="//TracedObject/DimensionSubType"/>
+      <eGenericType eTypeParameter="#//TracedObject/DimensionSubType"/>
     </eOperations>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensions" upperBound="-1" volatile="true" transient="true" derived="true">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensions" upperBound="-1"
+        volatile="true" transient="true" derived="true">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="get" value="return getDimensionsInternal();"/>
       </eAnnotations>
-      <eGenericType eTypeParameter="//TracedObject/DimensionSubType"/>
+      <eGenericType eTypeParameter="#//TracedObject/DimensionSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Dimension" abstract="true">
     <eTypeParameters name="ValueSubType">
-      <eBounds eClassifier="//Value">
+      <eBounds eClassifier="#//Value">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="values" upperBound="-1" containment="true">
-      <eGenericType eTypeParameter="//Dimension/ValueSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="values" upperBound="-1"
+        containment="true">
+      <eGenericType eTypeParameter="#//Dimension/ValueSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Value" abstract="true">
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1" eOpposite="//State/values">
-      <eGenericType eTypeParameter="//Value/StateSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1"
+        eOpposite="#//State/values">
+      <eGenericType eTypeParameter="#//Value/StateSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="State" abstract="true">
     <eTypeParameters name="StepSubType">
-      <eBounds eClassifier="//Step">
+      <eBounds eClassifier="#//Step">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="ValueSubType">
-      <eBounds eClassifier="//Value">
+      <eBounds eClassifier="#//Value">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="startedSteps" upperBound="-1" eOpposite="//Step/startingState">
-      <eGenericType eTypeParameter="//State/StepSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="startedSteps" upperBound="-1"
+        eOpposite="#//Step/startingState">
+      <eGenericType eTypeParameter="#//State/StepSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="endedSteps" upperBound="-1" eOpposite="//Step/endingState">
-      <eGenericType eTypeParameter="//State/StepSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="endedSteps" upperBound="-1"
+        eOpposite="#//Step/endingState">
+      <eGenericType eTypeParameter="#//State/StepSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="values" upperBound="-1" eOpposite="//Value/states">
-      <eGenericType eTypeParameter="//State/ValueSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="values" upperBound="-1"
+        eOpposite="#//Value/states">
+      <eGenericType eTypeParameter="#//State/ValueSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
 </ecore:EPackage>

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/model/GenericTraceImpl.ecore
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/model/GenericTraceImpl.ecore
@@ -101,4 +101,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="referenceValues" upperBound="-1"
         eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="IntegerObjectAttributeValue" eSuperTypes="#//GenericAttributeValue">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="attributeValue" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EIntegerObject"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/model/LaunchConfiguration.ecore
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/model/LaunchConfiguration.ecore
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="launchconfiguration" nsURI="http://www.gemoc.org/launch_configuration" nsPrefix="launchconfiguration">
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="launchconfiguration" nsURI="http://www.gemoc.org/launch_configuration"
+    nsPrefix="launchconfiguration">
   <eClassifiers xsi:type="ecore:EDataType" name="ISerializable" instanceClassName="byte[]"/>
   <eClassifiers xsi:type="ecore:EClass" name="LaunchConfiguration">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="parameters" upperBound="-1" eType="//LaunchConfigurationParameter" containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" lowerBound="1">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameters" upperBound="-1"
+        eType="#//LaunchConfigurationParameter" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="LaunchConfigurationParameter" abstract="true">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" defaultValueLiteral="">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
+        defaultValueLiteral=""/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="LanguageNameParameter" eSuperTypes="//LaunchConfigurationParameter"/>
-  <eClassifiers xsi:type="ecore:EClass" name="AddonExtensionParameter" eSuperTypes="//LaunchConfigurationParameter"/>
-  <eClassifiers xsi:type="ecore:EClass" name="ModelURIParameter" eSuperTypes="//LaunchConfigurationParameter"/>
-  <eClassifiers xsi:type="ecore:EClass" name="AnimatorURIParameter" eSuperTypes="//LaunchConfigurationParameter"/>
-  <eClassifiers xsi:type="ecore:EClass" name="EntryPointParameter" eSuperTypes="//LaunchConfigurationParameter"/>
-  <eClassifiers xsi:type="ecore:EClass" name="InitializationArgumentsParameter" eSuperTypes="//LaunchConfigurationParameter"/>
-  <eClassifiers xsi:type="ecore:EClass" name="ModelRootParameter" eSuperTypes="//LaunchConfigurationParameter"/>
-  <eClassifiers xsi:type="ecore:EClass" name="InitializationMethodParameter" eSuperTypes="//LaunchConfigurationParameter"/>
+  <eClassifiers xsi:type="ecore:EClass" name="LanguageNameParameter" eSuperTypes="#//LaunchConfigurationParameter"/>
+  <eClassifiers xsi:type="ecore:EClass" name="AddonExtensionParameter" eSuperTypes="#//LaunchConfigurationParameter"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ModelURIParameter" eSuperTypes="#//LaunchConfigurationParameter"/>
+  <eClassifiers xsi:type="ecore:EClass" name="AnimatorURIParameter" eSuperTypes="#//LaunchConfigurationParameter"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EntryPointParameter" eSuperTypes="#//LaunchConfigurationParameter"/>
+  <eClassifiers xsi:type="ecore:EClass" name="InitializationArgumentsParameter" eSuperTypes="#//LaunchConfigurationParameter"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ModelRootParameter" eSuperTypes="#//LaunchConfigurationParameter"/>
+  <eClassifiers xsi:type="ecore:EClass" name="InitializationMethodParameter" eSuperTypes="#//LaunchConfigurationParameter"/>
 </ecore:EPackage>

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/GenerictraceFactory.java
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/GenerictraceFactory.java
@@ -157,6 +157,15 @@ public interface GenerictraceFactory extends EFactory {
 	ManyReferenceValue createManyReferenceValue();
 
 	/**
+	 * Returns a new object of class '<em>Integer Object Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Integer Object Attribute Value</em>'.
+	 * @generated
+	 */
+	IntegerObjectAttributeValue createIntegerObjectAttributeValue();
+
+	/**
 	 * Returns the package supported by this factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/GenerictracePackage.java
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/GenerictracePackage.java
@@ -1007,13 +1007,59 @@ public interface GenerictracePackage extends EPackage {
 	int MANY_REFERENCE_VALUE_OPERATION_COUNT = GENERIC_REFERENCE_VALUE_OPERATION_COUNT + 0;
 
 	/**
+	 * The meta object id for the '{@link fr.inria.diverse.trace.commons.model.generictrace.impl.IntegerObjectAttributeValueImpl <em>Integer Object Attribute Value</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see fr.inria.diverse.trace.commons.model.generictrace.impl.IntegerObjectAttributeValueImpl
+	 * @see fr.inria.diverse.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getIntegerObjectAttributeValue()
+	 * @generated
+	 */
+	int INTEGER_OBJECT_ATTRIBUTE_VALUE = 19;
+
+	/**
+	 * The feature id for the '<em><b>States</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTEGER_OBJECT_ATTRIBUTE_VALUE__STATES = GENERIC_ATTRIBUTE_VALUE__STATES;
+
+	/**
+	 * The feature id for the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>Integer Object Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTEGER_OBJECT_ATTRIBUTE_VALUE_FEATURE_COUNT = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>Integer Object Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTEGER_OBJECT_ATTRIBUTE_VALUE_OPERATION_COUNT = GENERIC_ATTRIBUTE_VALUE_OPERATION_COUNT + 0;
+
+	/**
 	 * The meta object id for the '<em>ISerializable</em>' data type.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @see fr.inria.diverse.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getISerializable()
 	 * @generated
 	 */
-	int ISERIALIZABLE = 19;
+	int ISERIALIZABLE = 20;
 
 
 	/**
@@ -1338,6 +1384,27 @@ public interface GenerictracePackage extends EPackage {
 	EReference getManyReferenceValue_ReferenceValues();
 
 	/**
+	 * Returns the meta object for class '{@link fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue <em>Integer Object Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Integer Object Attribute Value</em>'.
+	 * @see fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue
+	 * @generated
+	 */
+	EClass getIntegerObjectAttributeValue();
+
+	/**
+	 * Returns the meta object for the attribute '{@link fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue#getAttributeValue <em>Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Attribute Value</em>'.
+	 * @see fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue#getAttributeValue()
+	 * @see #getIntegerObjectAttributeValue()
+	 * @generated
+	 */
+	EAttribute getIntegerObjectAttributeValue_AttributeValue();
+
+	/**
 	 * Returns the meta object for data type '<em>ISerializable</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1655,6 +1722,24 @@ public interface GenerictracePackage extends EPackage {
 		 * @generated
 		 */
 		EReference MANY_REFERENCE_VALUE__REFERENCE_VALUES = eINSTANCE.getManyReferenceValue_ReferenceValues();
+
+		/**
+		 * The meta object literal for the '{@link fr.inria.diverse.trace.commons.model.generictrace.impl.IntegerObjectAttributeValueImpl <em>Integer Object Attribute Value</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see fr.inria.diverse.trace.commons.model.generictrace.impl.IntegerObjectAttributeValueImpl
+		 * @see fr.inria.diverse.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getIntegerObjectAttributeValue()
+		 * @generated
+		 */
+		EClass INTEGER_OBJECT_ATTRIBUTE_VALUE = eINSTANCE.getIntegerObjectAttributeValue();
+
+		/**
+		 * The meta object literal for the '<em><b>Attribute Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = eINSTANCE.getIntegerObjectAttributeValue_AttributeValue();
 
 		/**
 		 * The meta object literal for the '<em>ISerializable</em>' data type.

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/IntegerObjectAttributeValue.java
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/IntegerObjectAttributeValue.java
@@ -1,0 +1,49 @@
+/**
+ */
+package fr.inria.diverse.trace.commons.model.generictrace;
+
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Integer Object Attribute Value</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue#getAttributeValue <em>Attribute Value</em>}</li>
+ * </ul>
+ *
+ * @see fr.inria.diverse.trace.commons.model.generictrace.GenerictracePackage#getIntegerObjectAttributeValue()
+ * @model
+ * @generated
+ */
+public interface IntegerObjectAttributeValue extends GenericAttributeValue {
+	/**
+	 * Returns the value of the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Attribute Value</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Attribute Value</em>' attribute.
+	 * @see #setAttributeValue(Integer)
+	 * @see fr.inria.diverse.trace.commons.model.generictrace.GenerictracePackage#getIntegerObjectAttributeValue_AttributeValue()
+	 * @model
+	 * @generated
+	 */
+	Integer getAttributeValue();
+
+	/**
+	 * Sets the value of the '{@link fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue#getAttributeValue <em>Attribute Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Attribute Value</em>' attribute.
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
+	void setAttributeValue(Integer value);
+
+} // IntegerObjectAttributeValue

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/impl/GenerictraceFactoryImpl.java
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/impl/GenerictraceFactoryImpl.java
@@ -72,6 +72,7 @@ public class GenerictraceFactoryImpl extends EFactoryImpl implements Generictrac
 			case GenerictracePackage.MANY_STRING_ATTRIBUTE_VALUE: return createManyStringAttributeValue();
 			case GenerictracePackage.SINGLE_REFERENCE_VALUE: return createSingleReferenceValue();
 			case GenerictracePackage.MANY_REFERENCE_VALUE: return createManyReferenceValue();
+			case GenerictracePackage.INTEGER_OBJECT_ATTRIBUTE_VALUE: return createIntegerObjectAttributeValue();
 			default:
 				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
 		}
@@ -255,6 +256,16 @@ public class GenerictraceFactoryImpl extends EFactoryImpl implements Generictrac
 	public ManyReferenceValue createManyReferenceValue() {
 		ManyReferenceValueImpl manyReferenceValue = new ManyReferenceValueImpl();
 		return manyReferenceValue;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public IntegerObjectAttributeValue createIntegerObjectAttributeValue() {
+		IntegerObjectAttributeValueImpl integerObjectAttributeValue = new IntegerObjectAttributeValueImpl();
+		return integerObjectAttributeValue;
 	}
 
 	/**

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/impl/GenerictracePackageImpl.java
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/impl/GenerictracePackageImpl.java
@@ -17,6 +17,7 @@ import fr.inria.diverse.trace.commons.model.generictrace.GenericValue;
 import fr.inria.diverse.trace.commons.model.generictrace.GenerictraceFactory;
 import fr.inria.diverse.trace.commons.model.generictrace.GenerictracePackage;
 import fr.inria.diverse.trace.commons.model.generictrace.IntegerAttributeValue;
+import fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue;
 import fr.inria.diverse.trace.commons.model.generictrace.ManyBooleanAttributeValue;
 import fr.inria.diverse.trace.commons.model.generictrace.ManyIntegerAttributeValue;
 import fr.inria.diverse.trace.commons.model.generictrace.ManyReferenceValue;
@@ -177,6 +178,13 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 	 * @generated
 	 */
 	private EClass manyReferenceValueEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass integerObjectAttributeValueEClass = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -533,6 +541,24 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EClass getIntegerObjectAttributeValue() {
+		return integerObjectAttributeValueEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getIntegerObjectAttributeValue_AttributeValue() {
+		return (EAttribute)integerObjectAttributeValueEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EDataType getISerializable() {
 		return iSerializableEDataType;
 	}
@@ -614,6 +640,9 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 
 		manyReferenceValueEClass = createEClass(MANY_REFERENCE_VALUE);
 		createEReference(manyReferenceValueEClass, MANY_REFERENCE_VALUE__REFERENCE_VALUES);
+
+		integerObjectAttributeValueEClass = createEClass(INTEGER_OBJECT_ATTRIBUTE_VALUE);
+		createEAttribute(integerObjectAttributeValueEClass, INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
 
 		// Create data types
 		iSerializableEDataType = createEDataType(ISERIALIZABLE);
@@ -716,6 +745,7 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 		genericValueEClass.getEGenericSuperTypes().add(g1);
 		singleReferenceValueEClass.getESuperTypes().add(this.getGenericReferenceValue());
 		manyReferenceValueEClass.getESuperTypes().add(this.getGenericReferenceValue());
+		integerObjectAttributeValueEClass.getESuperTypes().add(this.getGenericAttributeValue());
 
 		// Initialize classes, features, and operations; add parameters
 		initEClass(genericSequentialStepEClass, GenericSequentialStep.class, "GenericSequentialStep", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
@@ -768,6 +798,9 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 
 		initEClass(manyReferenceValueEClass, ManyReferenceValue.class, "ManyReferenceValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getManyReferenceValue_ReferenceValues(), ecorePackage.getEObject(), null, "referenceValues", null, 0, -1, ManyReferenceValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(integerObjectAttributeValueEClass, IntegerObjectAttributeValue.class, "IntegerObjectAttributeValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getIntegerObjectAttributeValue_AttributeValue(), ecorePackage.getEIntegerObject(), "attributeValue", null, 0, 1, IntegerObjectAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		// Initialize data types
 		initEDataType(iSerializableEDataType, byte[].class, "ISerializable", IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS);

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/impl/IntegerObjectAttributeValueImpl.java
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/impl/IntegerObjectAttributeValueImpl.java
@@ -1,0 +1,162 @@
+/**
+ */
+package fr.inria.diverse.trace.commons.model.generictrace.impl;
+
+import fr.inria.diverse.trace.commons.model.generictrace.GenerictracePackage;
+import fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue;
+
+import org.eclipse.emf.common.notify.Notification;
+
+import org.eclipse.emf.ecore.EClass;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>Integer Object Attribute Value</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link fr.inria.diverse.trace.commons.model.generictrace.impl.IntegerObjectAttributeValueImpl#getAttributeValue <em>Attribute Value</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class IntegerObjectAttributeValueImpl extends GenericAttributeValueImpl implements IntegerObjectAttributeValue {
+	/**
+	 * The default value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getAttributeValue()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final Integer ATTRIBUTE_VALUE_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getAttributeValue()
+	 * @generated
+	 * @ordered
+	 */
+	protected Integer attributeValue = ATTRIBUTE_VALUE_EDEFAULT;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected IntegerObjectAttributeValueImpl() {
+		super();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return GenerictracePackage.Literals.INTEGER_OBJECT_ATTRIBUTE_VALUE;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public Integer getAttributeValue() {
+		return attributeValue;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setAttributeValue(Integer newAttributeValue) {
+		Integer oldAttributeValue = attributeValue;
+		attributeValue = newAttributeValue;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, GenerictracePackage.INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE, oldAttributeValue, attributeValue));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case GenerictracePackage.INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				return getAttributeValue();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case GenerictracePackage.INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				setAttributeValue((Integer)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case GenerictracePackage.INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				setAttributeValue(ATTRIBUTE_VALUE_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case GenerictracePackage.INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				return ATTRIBUTE_VALUE_EDEFAULT == null ? attributeValue != null : !ATTRIBUTE_VALUE_EDEFAULT.equals(attributeValue);
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy()) return super.toString();
+
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (attributeValue: ");
+		result.append(attributeValue);
+		result.append(')');
+		return result.toString();
+	}
+
+} //IntegerObjectAttributeValueImpl

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/util/GenerictraceAdapterFactory.java
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/util/GenerictraceAdapterFactory.java
@@ -155,6 +155,10 @@ public class GenerictraceAdapterFactory extends AdapterFactoryImpl {
 				return createManyReferenceValueAdapter();
 			}
 			@Override
+			public Adapter caseIntegerObjectAttributeValue(IntegerObjectAttributeValue object) {
+				return createIntegerObjectAttributeValueAdapter();
+			}
+			@Override
 			public <StateSubType extends State<?, ?>> Adapter caseStep(Step<StateSubType> object) {
 				return createStepAdapter();
 			}
@@ -477,6 +481,20 @@ public class GenerictraceAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createManyReferenceValueAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue <em>Integer Object Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue
+	 * @generated
+	 */
+	public Adapter createIntegerObjectAttributeValueAdapter() {
 		return null;
 	}
 

--- a/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/util/GenerictraceSwitch.java
+++ b/trace/commons/plugins/fr.inria.diverse.trace.commons.model/src/fr/inria/diverse/trace/commons/model/generictrace/util/GenerictraceSwitch.java
@@ -236,6 +236,15 @@ public class GenerictraceSwitch<T> extends Switch<T> {
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
+			case GenerictracePackage.INTEGER_OBJECT_ATTRIBUTE_VALUE: {
+				IntegerObjectAttributeValue integerObjectAttributeValue = (IntegerObjectAttributeValue)theEObject;
+				T result = caseIntegerObjectAttributeValue(integerObjectAttributeValue);
+				if (result == null) result = caseGenericAttributeValue(integerObjectAttributeValue);
+				if (result == null) result = caseGenericValue(integerObjectAttributeValue);
+				if (result == null) result = caseValue(integerObjectAttributeValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
 			default: return defaultCase(theEObject);
 		}
 	}
@@ -522,6 +531,21 @@ public class GenerictraceSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseManyReferenceValue(ManyReferenceValue object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Integer Object Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Integer Object Attribute Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseIntegerObjectAttributeValue(IntegerObjectAttributeValue object) {
 		return null;
 	}
 

--- a/trace/generator/plugins/fr.inria.diverse.trace.gemoc/src/fr/inria/diverse/trace/gemoc/traceaddon/GenericTraceConstructor.java
+++ b/trace/generator/plugins/fr.inria.diverse.trace.gemoc/src/fr/inria/diverse/trace/gemoc/traceaddon/GenericTraceConstructor.java
@@ -45,6 +45,7 @@ import fr.inria.diverse.trace.commons.model.generictrace.GenericTracedObject;
 import fr.inria.diverse.trace.commons.model.generictrace.GenericValue;
 import fr.inria.diverse.trace.commons.model.generictrace.GenerictraceFactory;
 import fr.inria.diverse.trace.commons.model.generictrace.IntegerAttributeValue;
+import fr.inria.diverse.trace.commons.model.generictrace.IntegerObjectAttributeValue;
 import fr.inria.diverse.trace.commons.model.generictrace.ManyReferenceValue;
 import fr.inria.diverse.trace.commons.model.generictrace.SingleReferenceValue;
 import fr.inria.diverse.trace.commons.model.generictrace.StringAttributeValue;
@@ -107,6 +108,10 @@ public class GenericTraceConstructor implements ITraceConstructor {
 			} else if (eType == EcorePackage.Literals.ESTRING) {
 				final StringAttributeValue value = GenerictraceFactory.eINSTANCE.createStringAttributeValue();
 				value.setAttributeValue((String) object.eGet(mutableProperty));
+				result = value;
+			} else  if (eType == EcorePackage.Literals.EINTEGER_OBJECT) {
+				final IntegerObjectAttributeValue value = GenerictraceFactory.eINSTANCE.createIntegerObjectAttributeValue();
+				value.setAttributeValue((Integer) object.eGet(mutableProperty));
 				result = value;
 			}
 		} else if (mutableProperty instanceof EReference) {


### PR DESCRIPTION
The generic trace metamodel manages the cases Integer, Boolean, String for primitive values, but many types are missing.

This small PR adds `IntegerObject` as a new kind of value, which is required to create a generic trace in TFSM (or maybe it is LegacyFSM? not sure).