### PR TITLE
Small changes and fixes to the generic trace metamodel

### DIFF
--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTrace.ecore
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTrace.ecore
@@ -134,8 +134,8 @@
         containment="true">
       <eGenericType eTypeParameter="#//Trace/StepSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="tracedObjects" upperBound="-1"
-        containment="true">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="tracedObjects" ordered="false"
+        upperBound="-1" containment="true">
       <eGenericType eTypeParameter="#//Trace/TracedObjectSubtype"/>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1"
@@ -207,8 +207,8 @@
         eOpposite="#//Step/endingState">
       <eGenericType eTypeParameter="#//State/StepSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="values" upperBound="-1"
-        eOpposite="#//Value/states">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="values" ordered="false"
+        upperBound="-1" eOpposite="#//Value/states">
       <eGenericType eTypeParameter="#//State/ValueSubType"/>
     </eStructuralFeatures>
   </eClassifiers>

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTrace.genmodel
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTrace.genmodel
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
-    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/fr.inria.diverse.trace.commons.model/src" modelPluginID="fr.inria.diverse.trace.commons.model"
+    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.eclipse.gemoc.trace.commons.model/src" modelPluginID="org.eclipse.gemoc.trace.commons.model"
     modelName="GenericTrace" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
     importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false"
     usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore LaunchConfiguration.genmodel#//launchconfiguration"
     operationReflection="true" importOrganizing="true">
   <foreignModel>GenericTrace.ecore</foreignModel>
-  <genPackages prefix="Trace" basePackage="fr.inria.diverse.trace.commons.model" disposableProviderFactory="true"
+  <genPackages prefix="Trace" basePackage="org.eclipse.gemoc.trace.commons.model" disposableProviderFactory="true"
       ecorePackage="GenericTrace.ecore#/">
     <genDataTypes ecoreDataType="GenericTrace.ecore#//ISerializable"/>
     <genClasses ecoreClass="GenericTrace.ecore#//MSEOccurrence">

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTraceImpl.genmodel
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTraceImpl.genmodel
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
-    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/fr.inria.diverse.trace.commons.model/src" modelPluginID="fr.inria.diverse.trace.commons.model"
+    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.eclipse.gemoc.trace.commons.model/src" modelPluginID="org.eclipse.gemoc.trace.commons.model"
     modelName="GenericTraceImpl" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
     importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false"
     usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore GenericTrace.genmodel#//trace LaunchConfiguration.genmodel#//launchconfiguration"
     operationReflection="true" importOrganizing="true">
   <foreignModel>GenericTraceImpl.ecore</foreignModel>
-  <genPackages prefix="Generictrace" basePackage="fr.inria.diverse.trace.commons.model"
+  <genPackages prefix="Generictrace" basePackage="org.eclipse.gemoc.trace.commons.model"
       disposableProviderFactory="true" ecorePackage="GenericTraceImpl.ecore#/">
     <genDataTypes ecoreDataType="GenericTraceImpl.ecore#//ISerializable"/>
     <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericSequentialStep"/>

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/LaunchConfiguration.genmodel
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/LaunchConfiguration.genmodel
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
-    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/fr.inria.diverse.trace.commons.model/src" modelPluginID="fr.inria.diverse.trace.commons.model"
+    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.eclipse.gemoc.trace.commons.model/src" modelPluginID="org.eclipse.gemoc.trace.commons.model"
     modelName="LaunchConfiguration" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
     importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false"
     operationReflection="true" importOrganizing="true">
   <foreignModel>LaunchConfiguration.ecore</foreignModel>
-  <genPackages prefix="Launchconfiguration" basePackage="fr.inria.diverse.trace.commons.model"
+  <genPackages prefix="Launchconfiguration" basePackage="org.eclipse.gemoc.trace.commons.model"
       disposableProviderFactory="true" ecorePackage="LaunchConfiguration.ecore#/">
     <genDataTypes ecoreDataType="LaunchConfiguration.ecore#//ISerializable"/>
     <genClasses ecoreClass="LaunchConfiguration.ecore#//LaunchConfiguration">

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/trace/State.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/trace/State.java
@@ -81,7 +81,7 @@ public interface State<StepSubType extends Step<?>, ValueSubType extends Value<?
 	 * @return the value of the '<em>Values</em>' reference list.
 	 * @see org.eclipse.gemoc.trace.commons.model.trace.TracePackage#getState_Values()
 	 * @see org.eclipse.gemoc.trace.commons.model.trace.Value#getStates
-	 * @model opposite="states"
+	 * @model opposite="states" ordered="false"
 	 * @generated
 	 */
 	EList<ValueSubType> getValues();

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/trace/Trace.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/trace/Trace.java
@@ -74,7 +74,7 @@ public interface Trace<StepSubType extends Step<?>, TracedObjectSubtype extends 
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Traced Objects</em>' containment reference list.
 	 * @see org.eclipse.gemoc.trace.commons.model.trace.TracePackage#getTrace_TracedObjects()
-	 * @model containment="true"
+	 * @model containment="true" ordered="false"
 	 * @generated
 	 */
 	EList<TracedObjectSubtype> getTracedObjects();

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/trace/TracedObject.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/trace/TracedObject.java
@@ -43,7 +43,7 @@ public interface TracedObject<DimensionSubType extends Dimension<?>> extends EOb
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Dimensions</em>' reference list.
 	 * @see org.eclipse.gemoc.trace.commons.model.trace.TracePackage#getTracedObject_Dimensions()
-	 * @model transient="true" volatile="true"
+	 * @model transient="true" volatile="true" derived="true"
 	 *        annotation="http://www.eclipse.org/emf/2002/GenModel get='return getDimensionsInternal();'"
 	 * @generated
 	 */

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/trace/impl/TracePackageImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/trace/impl/TracePackageImpl.java
@@ -857,14 +857,14 @@ public class TracePackageImpl extends EPackageImpl implements TracePackage {
 		g1 = createEGenericType(traceEClass_StepSubType);
 		initEReference(getTrace_RootStep(), g1, null, "rootStep", null, 1, 1, Trace.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		g1 = createEGenericType(traceEClass_TracedObjectSubtype);
-		initEReference(getTrace_TracedObjects(), g1, null, "tracedObjects", null, 0, -1, Trace.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getTrace_TracedObjects(), g1, null, "tracedObjects", null, 0, -1, Trace.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		g1 = createEGenericType(traceEClass_StateSubType);
 		initEReference(getTrace_States(), g1, null, "states", null, 0, -1, Trace.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getTrace_Launchconfiguration(), theLaunchconfigurationPackage.getLaunchConfiguration(), null, "launchconfiguration", null, 1, 1, Trace.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(tracedObjectEClass, TracedObject.class, "TracedObject", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		g1 = createEGenericType(tracedObjectEClass_DimensionSubType);
-		initEReference(getTracedObject_Dimensions(), g1, null, "dimensions", null, 0, -1, TracedObject.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getTracedObject_Dimensions(), g1, null, "dimensions", null, 0, -1, TracedObject.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 
 		EOperation op = initEOperation(getTracedObject__GetDimensionsInternal(), null, "getDimensionsInternal", 0, -1, IS_UNIQUE, IS_ORDERED);
 		g1 = createEGenericType(tracedObjectEClass_DimensionSubType);
@@ -884,7 +884,7 @@ public class TracePackageImpl extends EPackageImpl implements TracePackage {
 		g1 = createEGenericType(stateEClass_StepSubType);
 		initEReference(getState_EndedSteps(), g1, this.getStep_EndingState(), "endedSteps", null, 0, -1, State.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		g1 = createEGenericType(stateEClass_ValueSubType);
-		initEReference(getState_Values(), g1, this.getValue_States(), "values", null, 0, -1, State.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getState_Values(), g1, this.getValue_States(), "values", null, 0, -1, State.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
 		// Initialize data types
 		initEDataType(iSerializableEDataType, byte[].class, "ISerializable", IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS);


### PR DESCRIPTION
Mostly to make the references'tracedObjects' and 'values' unordered