### PR TITLE
Remove confusion AbstractDSLLaunchConfigurationDelegateUI classes

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/AbstractGemocLauncher.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/AbstractGemocLauncher.java
@@ -20,7 +20,7 @@ import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonS
 import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfiguration;
 
 
-abstract public class AbstractGemocLauncher extends org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateUI {
+abstract public class AbstractGemocLauncher extends org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateUI2 {
 
 	// warning this MODEL_ID must be the same as the one in the ModelLoader in order to enable correctly the breakpoints
 	public final static String MODEL_ID = org.eclipse.gemoc.executionframework.engine.ui.Activator.PLUGIN_ID+".debugModel";

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/AbstractGemocLauncher.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/AbstractGemocLauncher.java
@@ -20,7 +20,7 @@ import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonS
 import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfiguration;
 
 
-abstract public class AbstractGemocLauncher extends org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateUI2 {
+abstract public class AbstractGemocLauncher extends org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateSiriusUI {
 
 	// warning this MODEL_ID must be the same as the one in the ModelLoader in order to enable correctly the breakpoints
 	public final static String MODEL_ID = org.eclipse.gemoc.executionframework.engine.ui.Activator.PLUGIN_ID+".debugModel";

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/tabs/LaunchConfigurationMainTab.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/tabs/LaunchConfigurationMainTab.java
@@ -59,7 +59,7 @@ import org.eclipse.gemoc.xdsmlframework.ui.utils.dialogs.SelectMainMethodDialog;
 import org.osgi.framework.Bundle;
 
 import org.eclipse.gemoc.dsl.debug.ide.launch.AbstractDSLLaunchConfigurationDelegate;
-import org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateUI;
+import org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateSiriusUI;
 
 /**
  * Sequential engine launch configuration main tab
@@ -168,7 +168,7 @@ public class LaunchConfigurationMainTab extends LaunchConfigurationTab {
 				AbstractDSLLaunchConfigurationDelegate.RESOURCE_URI,
 				this._modelLocationText.getText());
 		configuration.setAttribute(
-				AbstractDSLLaunchConfigurationDelegateUI.SIRIUS_RESOURCE_URI,
+				AbstractDSLLaunchConfigurationDelegateSiriusUI.SIRIUS_RESOURCE_URI,
 				this._siriusRepresentationLocationText.getText());
 		configuration.setAttribute(RunConfiguration.LAUNCH_DELAY,
 				Integer.parseInt(_delayText.getText()));

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/launch/AbstractDSLLaunchConfigurationDelegateSiriusUI.java
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/launch/AbstractDSLLaunchConfigurationDelegateSiriusUI.java
@@ -37,7 +37,7 @@ import org.eclipse.ui.PlatformUI;
  * 
  * @author <a href="mailto:yvan.lussaud@obeo.fr">Yvan Lussaud</a>
  */
-public abstract class AbstractDSLLaunchConfigurationDelegateUI2 extends org.eclipse.gemoc.dsl.debug.ide.ui.launch.AbstractDSLLaunchConfigurationDelegateUI {
+public abstract class AbstractDSLLaunchConfigurationDelegateSiriusUI extends org.eclipse.gemoc.dsl.debug.ide.ui.launch.AbstractDSLLaunchConfigurationDelegateUI {
 
 	/**
 	 * The Sirius {@link org.eclipse.emf.ecore.resource.Resource Resource}

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/launch/AbstractDSLLaunchConfigurationDelegateUI2.java
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/launch/AbstractDSLLaunchConfigurationDelegateUI2.java
@@ -10,10 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch;
 
-import org.eclipse.gemoc.dsl.debug.ide.adapter.IDSLCurrentInstructionListener;
-import org.eclipse.gemoc.dsl.debug.ide.sirius.ui.services.AbstractDSLDebuggerServices;
-import org.eclipse.gemoc.dsl.debug.ide.ui.launch.DSLLaunchConfigurationTab;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,6 +20,9 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gemoc.dsl.debug.ide.adapter.IDSLCurrentInstructionListener;
+import org.eclipse.gemoc.dsl.debug.ide.sirius.ui.services.AbstractDSLDebuggerServices;
+import org.eclipse.gemoc.dsl.debug.ide.ui.launch.DSLLaunchConfigurationTab;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.sirius.business.api.helper.SiriusUtil;
 import org.eclipse.sirius.business.api.session.Session;
@@ -31,13 +30,14 @@ import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.ui.PlatformUI;
 
 /**
- * A Sirius implementation of {@link org.eclipse.gemoc.dsl.debug.ide.launch.AbstractDSLLaunchConfigurationDelegate
+ * A Sirius implementation of
+ * {@link org.eclipse.gemoc.dsl.debug.ide.launch.AbstractDSLLaunchConfigurationDelegate
  * AbstractDSLLaunchConfigurationDelegate} with {@link org.eclipse.debug.ui.ILaunchShortcut ILaunchShortcut}
  * support.
  * 
  * @author <a href="mailto:yvan.lussaud@obeo.fr">Yvan Lussaud</a>
  */
-public abstract class AbstractDSLLaunchConfigurationDelegateUI extends org.eclipse.gemoc.dsl.debug.ide.ui.launch.AbstractDSLLaunchConfigurationDelegateUI {
+public abstract class AbstractDSLLaunchConfigurationDelegateUI2 extends org.eclipse.gemoc.dsl.debug.ide.ui.launch.AbstractDSLLaunchConfigurationDelegateUI {
 
 	/**
 	 * The Sirius {@link org.eclipse.emf.ecore.resource.Resource Resource}

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/launch/DSLLaunchConfigurationTab.java
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/launch/DSLLaunchConfigurationTab.java
@@ -50,7 +50,7 @@ import org.eclipse.ui.model.WorkbenchLabelProvider;
 public class DSLLaunchConfigurationTab extends org.eclipse.gemoc.dsl.debug.ide.ui.launch.DSLLaunchConfigurationTab {
 
 	/**
-	 * The {@link Text} used for the {@link AbstractDSLLaunchConfigurationDelegateUI2#SIRIUS_RESOURCE_URI}.
+	 * The {@link Text} used for the {@link AbstractDSLLaunchConfigurationDelegateSiriusUI#SIRIUS_RESOURCE_URI}.
 	 */
 	private Text siriusResourceURIText;
 
@@ -67,7 +67,7 @@ public class DSLLaunchConfigurationTab extends org.eclipse.gemoc.dsl.debug.ide.u
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
 		super.setDefaults(configuration);
-		configuration.setAttribute(AbstractDSLLaunchConfigurationDelegateUI2.SIRIUS_RESOURCE_URI, "");
+		configuration.setAttribute(AbstractDSLLaunchConfigurationDelegateSiriusUI.SIRIUS_RESOURCE_URI, "");
 	}
 
 	/**
@@ -94,7 +94,7 @@ public class DSLLaunchConfigurationTab extends org.eclipse.gemoc.dsl.debug.ide.u
 	@Override
 	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
 		super.performApply(configuration);
-		configuration.setAttribute(AbstractDSLLaunchConfigurationDelegateUI2.SIRIUS_RESOURCE_URI,
+		configuration.setAttribute(AbstractDSLLaunchConfigurationDelegateSiriusUI.SIRIUS_RESOURCE_URI,
 				siriusResourceURIText.getText());
 	}
 
@@ -106,7 +106,7 @@ public class DSLLaunchConfigurationTab extends org.eclipse.gemoc.dsl.debug.ide.u
 		try {
 			if (res) {
 				String siriusResourceURI = launchConfig.getAttribute(
-						AbstractDSLLaunchConfigurationDelegateUI2.SIRIUS_RESOURCE_URI, "");
+						AbstractDSLLaunchConfigurationDelegateSiriusUI.SIRIUS_RESOURCE_URI, "");
 				IFile resourceFile = ResourcesPlugin.getWorkspace().getRoot().getFile(
 						new Path(siriusResourceURI));
 				Resource resource = null;

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/launch/DSLLaunchConfigurationTab.java
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/launch/DSLLaunchConfigurationTab.java
@@ -50,7 +50,7 @@ import org.eclipse.ui.model.WorkbenchLabelProvider;
 public class DSLLaunchConfigurationTab extends org.eclipse.gemoc.dsl.debug.ide.ui.launch.DSLLaunchConfigurationTab {
 
 	/**
-	 * The {@link Text} used for the {@link AbstractDSLLaunchConfigurationDelegateUI#SIRIUS_RESOURCE_URI}.
+	 * The {@link Text} used for the {@link AbstractDSLLaunchConfigurationDelegateUI2#SIRIUS_RESOURCE_URI}.
 	 */
 	private Text siriusResourceURIText;
 
@@ -67,7 +67,7 @@ public class DSLLaunchConfigurationTab extends org.eclipse.gemoc.dsl.debug.ide.u
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
 		super.setDefaults(configuration);
-		configuration.setAttribute(AbstractDSLLaunchConfigurationDelegateUI.SIRIUS_RESOURCE_URI, "");
+		configuration.setAttribute(AbstractDSLLaunchConfigurationDelegateUI2.SIRIUS_RESOURCE_URI, "");
 	}
 
 	/**
@@ -94,7 +94,7 @@ public class DSLLaunchConfigurationTab extends org.eclipse.gemoc.dsl.debug.ide.u
 	@Override
 	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
 		super.performApply(configuration);
-		configuration.setAttribute(AbstractDSLLaunchConfigurationDelegateUI.SIRIUS_RESOURCE_URI,
+		configuration.setAttribute(AbstractDSLLaunchConfigurationDelegateUI2.SIRIUS_RESOURCE_URI,
 				siriusResourceURIText.getText());
 	}
 
@@ -106,7 +106,7 @@ public class DSLLaunchConfigurationTab extends org.eclipse.gemoc.dsl.debug.ide.u
 		try {
 			if (res) {
 				String siriusResourceURI = launchConfig.getAttribute(
-						AbstractDSLLaunchConfigurationDelegateUI.SIRIUS_RESOURCE_URI, "");
+						AbstractDSLLaunchConfigurationDelegateUI2.SIRIUS_RESOURCE_URI, "");
 				IFile resourceFile = ResourcesPlugin.getWorkspace().getRoot().getFile(
 						new Path(siriusResourceURI));
 				Resource resource = null;


### PR DESCRIPTION
To better distinguish the classes

`org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateUI`

and

`org.eclipse.gemoc.dsl.debug.ide.ui.launch.AbstractDSLLaunchConfigurationDelegateUI`

this commit renames the former to `AbstractDSLLaunchConfigurationDelegateUI2`

For some reason, this caused me really strange compilation errors in Eclipse, while probably tycho is not bothered.